### PR TITLE
fix Ruby 3.2 removed File.exists?

### DIFF
--- a/test/concerns/test_seedable/seed.rb
+++ b/test/concerns/test_seedable/seed.rb
@@ -34,12 +34,12 @@ module TestSeedable
 
       case seed
       when :all
-        load(db_seeds) if File.exists?(db_seeds)
-        load(test_seeds) if File.exists?(test_seeds)
+        load(db_seeds) if File.exist?(db_seeds)
+        load(test_seeds) if File.exist?(test_seeds)
       when :db
-        load(db_seeds) if File.exists?(db_seeds)
+        load(db_seeds) if File.exist?(db_seeds)
       when :test
-        load(test_seeds) if File.exists?(test_seeds)
+        load(test_seeds) if File.exist?(test_seeds)
       else
         raise('unexpected seed argument. use :all, :db or :test')
       end

--- a/test/support/effective_test_bot_form_faker.rb
+++ b/test/support/effective_test_bot_form_faker.rb
@@ -166,7 +166,7 @@ module EffectiveTestBotFormFaker
     # If this is a file field, make sure the file is present at Rails.root/test/fixtures/
     if fill.present? && fill != :unselect && field_name == 'input_file'
       filename = (fill.to_s.include?('/') ? fill : "#{Rails.root}/test/fixtures/#{fill}")
-      raise("Warning: Unable to load fill file #{fill}. Expected file #{filename}") unless File.exists?(filename)
+      raise("Warning: Unable to load fill file #{fill}. Expected file #{filename}") unless File.exist?(filename)
       return filename
     end
 


### PR DESCRIPTION
`File.exists?` is deprecated way back in Ruby 2.1 and is completely removed in Ruby 3.2