### PR TITLE
handle edge case of checkbox already checked

### DIFF
--- a/test/support/effective_test_bot_form_filler.rb
+++ b/test/support/effective_test_bot_form_filler.rb
@@ -149,12 +149,15 @@ module EffectiveTestBotFormFiller
   end
 
   def fill_input_checkbox(field, value)
-    return if [nil, false].include?(value)
-
     if field['class'].to_s.include?('custom-control-input')
       label = all("label[for='#{field['id']}']", wait: false).first
-      return label.click() if label
+      if label
+        label.click if field.checked? ^ value # click if check status is different from value
+        return
+      end
     end
+
+    return if [nil, false].include?(value)
 
     begin
       field.set(value)


### PR DESCRIPTION
Functionality is unchanged (fill value of checkbox will set the checked state) except in special case where checkbox is already checked on the form, in which the checkbox checked state will be set to opposite of fill value. (I really really thought about this, and fill value of true should ensure checkbox is checked, and fill value of false should uncheck.)

This PR alters this edge case (where checkbox is already checked). So on an already checked checkbox, a fill value of true will do nothing, and a fill value of false will uncheck the checkbox.