### PR TITLE
fixed assert_assigns default message

### DIFF
--- a/test/support/effective_test_bot_assertions.rb
+++ b/test/support/effective_test_bot_assertions.rb
@@ -190,7 +190,7 @@ module EffectiveTestBotAssertions
   # assert_assigns :current_user, 'there should a current user'
   def assert_assigns(key = nil, value = nil, message: nil)
     if key.present? && value.present?
-      assert_equal value, assigns[key.to_s], message || "(assigns) Expected assigns[#{key}] to equal #{value}. Instead, it was: #{value}"
+      assert_equal value, assigns[key.to_s], message || "(assigns) Expected assigns[#{key}] to equal #{value.inspect}. Instead, it was: #{assigns[key].inspect}"
     elsif key.present?
       assert assigns[key.to_s].present?, message || "(assigns) Expected @#{key} to be assigned"
     else


### PR DESCRIPTION
default message was: expected value but it was value, fixed to: expected value but was assigns[key]