### PR TITLE
fix "Test is missing assertions" warning for assert_email

### DIFF
--- a/test/support/effective_test_bot_assertions.rb
+++ b/test/support/effective_test_bot_assertions.rb
@@ -315,7 +315,11 @@ module EffectiveTestBotAssertions
       matches &&= (html_body.present? && html_body.include?('<meta')) if html_layout
       matches &&= (html_body.blank? && plain_body.blank? && message_body.exclude?('<meta')) if plain_layout
 
-      return retval if matches
+      # assert_email is true on any delivery that match
+      if matches
+        assert true # self.assertions += 1
+        return retval 
+      end
     end
 
     expected = [


### PR DESCRIPTION
 In Rails 7.2, you get "Test is missing assertions" warning. This happens when a test case has assertions that is solely `assert_email` with `to` argument, which doesn't increment `self.assertions` count when successfully matches.

So we can either call `assert` directly, or manually `self.assertions += 1`. I think `assert true` is more in line with the `assert false` that is called later on.
